### PR TITLE
handle Iterables of Result objects

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -10,10 +10,12 @@ extension FutureExtensions<O, E> on Future<Result<O, E>> {
   Future<O> unwrap() async => (await this).unwrap();
 
   /// awaits the [Future] and executes the unwrapOr of the [Result].
-  Future<O> unwrapOr(O defaultValue) async => (await this).unwrapOr(defaultValue);
+  Future<O> unwrapOr(O defaultValue) async =>
+      (await this).unwrapOr(defaultValue);
 
   /// awaits the [Future] and executes the unwrapOrElse of the [Result].
-  Future<O> unwrapOrElse(O Function() fn) async => (await this).unwrapOrElse(fn);
+  Future<O> unwrapOrElse(O Function() fn) async =>
+      (await this).unwrapOrElse(fn);
 
   /// awaits the [Future] and executes the unwrapOrElseAsync of the [Result].
   Future<O> unwrapOrElseAsync(Future<O> Function() fn) async =>
@@ -41,5 +43,26 @@ extension FutureExtensions<O, E> on Future<Result<O, E>> {
     Future<Result<O, E2>> Function(E err) fn,
   ) async {
     return await (await this).orElseAsync(fn);
+  }
+}
+
+extension IterableExtensions<L, E> on Iterable<Result<L, E>> {
+  /// __EXPERIMENTAL:__ might change in the Future.
+  ///
+  /// executes the Function [fn] for every element in the iterable for as long
+  /// as there are any and the [Result] of fn isn't an [Err].
+  Result<O, E>? whileOk<O>(Result<O, E> Function(O? lastValue, L it) fn) {
+    Result<O, E>? last;
+
+    final iter = iterator;
+    while (iter.moveNext() && last is Ok<O, E>?) {
+      switch (iter.current) {
+        case Ok(value: final it):
+          last = fn(last?.value, it);
+        case Err(:final error):
+          return Err(error);
+      }
+    }
+    return last;
   }
 }

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -17,6 +17,8 @@ void extensionTests() {
   test("test Future andThenAsync", testAndThenAsync);
   test("test Future orElse", testOrElse);
   test("test Future orElseAsync", testOrElseAsync);
+  test("test Iterable whileOk", testWhileOk);
+  test("test Iterable whileOk until it's not", testUntilNotOk);
 }
 
 void setTestsUp() {
@@ -61,27 +63,72 @@ Future<void> testAndThen() async {
 
 Future<void> testAndThenAsync() async {
   expect(await ok.andThenAsync((ok) async => Ok(ok.toString())).unwrap(), "42");
-  expect((await err.andThenAsync((ok) async => Ok(ok.toString())) as Err).error, "fooo");
+  expect((await err.andThenAsync((ok) async => Ok(ok.toString())) as Err).error,
+      "fooo");
 }
 
 Future<void> testOrElse() async {
   expect(
-    await ok.andThen((ok) => Ok(ok.toString())).orElse((err) => Ok(err)).unwrap(),
+    await ok
+        .andThen((ok) => Ok(ok.toString()))
+        .orElse((err) => Ok(err))
+        .unwrap(),
     "42",
   );
   expect(
-    await err.andThen((ok) => Ok(ok.toString())).orElse((err) => Ok(err)).unwrap(),
+    await err
+        .andThen((ok) => Ok(ok.toString()))
+        .orElse((err) => Ok(err))
+        .unwrap(),
     "fooo",
   );
 }
 
 Future<void> testOrElseAsync() async {
   expect(
-    await ok.andThen((ok) => Ok(ok.toString())).orElseAsync((err) async => Ok(err)).unwrap(),
+    await ok
+        .andThen((ok) => Ok(ok.toString()))
+        .orElseAsync((err) async => Ok(err))
+        .unwrap(),
     "42",
   );
   expect(
-    await err.andThen((ok) => Ok(ok.toString())).orElseAsync((err) async => Ok(err)).unwrap(),
+    await err
+        .andThen((ok) => Ok(ok.toString()))
+        .orElseAsync((err) async => Ok(err))
+        .unwrap(),
     "fooo",
+  );
+}
+
+void testWhileOk() {
+  expect(
+    <Result<int, String>>[
+      Ok(1),
+      Ok(2),
+      Ok(3),
+      Ok(4),
+      Ok(5),
+    ].whileOk<int>((lastValue, it) => switch (lastValue) {
+          int value => Ok(value + it),
+          null => Ok(it),
+        }),
+    Ok(15),
+  );
+}
+
+void testUntilNotOk() {
+  expect(
+    <Result<int, String>>[
+      Ok(1),
+      Ok(2),
+      Ok(3),
+      Err("everything sucks"),
+      Ok(5),
+    ].whileOk<int>((lastValue, it) => switch (lastValue) {
+          int value => Ok(value + it),
+          null => Ok(it),
+        }),
+    Err("everything sucks"),
   );
 }


### PR DESCRIPTION
added functionality to handle Iterables of Result objects for as long as there is no Err.